### PR TITLE
Add lint workflow and docs, fix Ubuntu build dependency

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -89,7 +89,7 @@ jobs:
     - name: Install dependencies
       run: |
         sudo apt-get update -qq
-        sudo apt-get install -y --no-install-recommends dc debootstrap librsvg2-bin zstd xml2 syslinux-utils xorriso
+        sudo apt-get install -y --no-install-recommends dc debootstrap librsvg2-bin zstd libxml2-utils syslinux-utils xorriso
         [ ${{ inputs.compat-distro }} != devuan ] || curl https://git.devuan.org/devuan/debootstrap/raw/branch/master/scripts/ceres | sudo tee /usr/share/debootstrap/scripts/`echo ${{ inputs.compat-distro-version }} | sed s/64$//`
     - name: 0setup
       timeout-minutes: 10

--- a/.github/workflows/lint-test.yml
+++ b/.github/workflows/lint-test.yml
@@ -1,0 +1,17 @@
+name: lint-and-test
+
+on:
+  push:
+  pull_request:
+
+jobs:
+  lint-test:
+    runs-on: ubuntu-latest
+    steps:
+    - uses: actions/checkout@v4
+    - name: Install dependencies
+      run: sudo apt-get update && sudo apt-get install -y shellcheck
+    - name: Run ShellCheck
+      run: shellcheck --severity=error merge2out tests/*.sh
+    - name: Run smoke tests
+      run: bash tests/merge2out_help.sh

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -1,0 +1,20 @@
+# Contributing
+
+Thank you for your interest in contributing to woof-CE.
+
+## Development workflow
+- Fork the repository and create your changes on a topic branch.
+- Run `shellcheck --severity=error` on any shell scripts you touch.
+- Execute the smoke tests in `tests/` to ensure key build steps still work:
+  ```bash
+  bash tests/merge2out_help.sh
+  ```
+- Commits should be descriptive and reference related issues when possible.
+
+## Coding guidelines
+- Shell scripts should target POSIX `sh` unless `bash` features are required.
+- Avoid style warnings reported by ShellCheck where practical.
+- Keep scripts small and composable; functions are preferred over large blocks.
+
+## Reporting issues
+If you encounter problems, please include steps to reproduce and relevant logs in your bug report.

--- a/TROUBLESHOOTING.md
+++ b/TROUBLESHOOTING.md
@@ -1,0 +1,10 @@
+# Troubleshooting
+
+Common issues and quick fixes:
+
+- **Missing packages**: Ensure build dependencies such as `debootstrap`, `xorriso` and `zstd` are installed. The CI workflow shows the full list.
+- **Permission errors**: Many scripts expect to run as root. Use `sudo` where appropriate.
+- **Failed downloads**: Check your network connectivity and the URLs in `DISTRO_COMPAT_REPOS-*` files. Mirrors sometimes change.
+- **Stale output directories**: Remove any existing `woof-out_*` directories before starting a new build to avoid contamination from previous runs.
+
+For more help, consult the project wiki or open an issue with detailed logs.

--- a/kernel-kit/README.md
+++ b/kernel-kit/README.md
@@ -1,0 +1,13 @@
+# kernel-kit
+
+Tools and configuration snippets for building Puppy Linux kernels.
+
+## Key files
+- `build.sh` – entry point for compiling a kernel using the selected `*build.conf` file.
+- `configs_*` – default kernel configuration fragments for each architecture.
+- `patches/` – optional patch sets applied during kernel compilation.
+
+To build a kernel, adjust the appropriate `*-build.conf` file and run:
+```bash
+./build.sh
+```

--- a/tests/merge2out_help.sh
+++ b/tests/merge2out_help.sh
@@ -1,0 +1,8 @@
+#!/usr/bin/env bash
+set -euo pipefail
+
+output=$(./merge2out --help 2>&1 || true)
+if [[ $output != *"build system"* ]]; then
+  echo "Unexpected output from merge2out --help" >&2
+  exit 1
+fi

--- a/woof-code/README.md
+++ b/woof-code/README.md
@@ -1,0 +1,11 @@
+# woof-code
+
+Core build scripts executed to assemble a Puppy Linux distribution.
+
+## Workflow
+1. `0setup` – prepare package repositories and resolve compatibility files.
+2. `1download` – fetch upstream packages and sources.
+3. `2createpackages` – generate Puppy-compliant packages.
+4. `3builddistro` – assemble the final ISO/SFS artifacts.
+
+Each script should be run in sequence inside a `woof-out_*` directory produced by `merge2out`.

--- a/woof-distro/README.md
+++ b/woof-distro/README.md
@@ -1,0 +1,9 @@
+# woof-distro
+
+Configuration data describing supported distributions and architectures.
+
+Each architecture directory (e.g., `x86_64/ubuntu/jammy64`) contains:
+- `DISTRO_SPECS` and related files defining repositories and package selections.
+- `Packages-*` lists enumerating available Puppy packages.
+
+`merge2out` uses these directories to generate a `woof-out_*` build tree.


### PR DESCRIPTION
## Summary
- add contributor guide, troubleshooting notes, and directory READMEs
- run shellcheck and smoke tests in new lint-and-test workflow
- replace missing `xml2` with `libxml2-utils` in build deps for Ubuntu 22.04

## Testing
- `shellcheck --severity=error merge2out tests/merge2out_help.sh`
- `bash tests/merge2out_help.sh`


------
https://chatgpt.com/codex/tasks/task_e_68a2381ef130832dab343f2eedaabc5c