### PR TITLE
Add build tool deps for jammy64 workflow

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -89,7 +89,7 @@ jobs:
     - name: Install dependencies
       run: |
         sudo apt-get update -qq
-        sudo apt-get install -y --no-install-recommends dc debootstrap librsvg2-bin zstd libxml2-utils syslinux-utils xorriso
+        sudo apt-get install -y --no-install-recommends dc debootstrap librsvg2-bin zstd libxml2-utils syslinux-utils xorriso meson ninja-build cmake
         [ ${{ inputs.compat-distro }} != devuan ] || curl https://git.devuan.org/devuan/debootstrap/raw/branch/master/scripts/ceres | sudo tee /usr/share/debootstrap/scripts/`echo ${{ inputs.compat-distro-version }} | sed s/64$//`
     - name: 0setup
       timeout-minutes: 10


### PR DESCRIPTION
## Summary
- install meson, ninja-build, and cmake in build workflow so jammy64's petbuilds compile properly

## Testing
- `bash tests/merge2out_help.sh`


------
https://chatgpt.com/codex/tasks/task_e_68a23c25e8a8832da55ebb796f60af91