### PR TITLE
Improve merge2out help and test automation

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -4,11 +4,7 @@ Thank you for your interest in contributing to woof-CE.
 
 ## Development workflow
 - Fork the repository and create your changes on a topic branch.
-- Run `shellcheck --severity=error` on any shell scripts you touch.
-- Execute the smoke tests in `tests/` to ensure key build steps still work:
-  ```bash
-  bash tests/merge2out_help.sh
-  ```
+- Run `./run-tests.sh` to execute ShellCheck and the test suite.
 - Commits should be descriptive and reference related issues when possible.
 
 ## Coding guidelines

--- a/merge2out
+++ b/merge2out
@@ -3,9 +3,23 @@
 
 WOOF_VERSION=9
 
+case "$1" in
+    --help|-h)
+        cat <<'EOF'
+Usage: merge2out [CONFIG_DIR]
+
+This script merges woof-arch, woof-code,
+woof-distro, kernel-kit and initrd-progs to ../woof-out_*.
+See README.md. It's not advised to use the build system
+in a distro other than a recent WOOFCE Puppy.
+EOF
+        exit 0
+        ;;
+esac
+
 if [ ! -f /etc/rc.d/PUPSTATE -a -z "$GITHUB_ACTIONS" ] ; then
-	echo "It's not advised to use the build system"
-	echo "in a distro other than  a recent WOOFCE Puppy"
+        echo "It's not advised to use the build system"
+        echo "in a distro other than  a recent WOOFCE Puppy"
 	echo
 	echo "You should be able to do the building using run-woof"
 	echo "	https://github.com/puppylinux-woof-CE/run_woof"

--- a/run-tests.sh
+++ b/run-tests.sh
@@ -1,0 +1,7 @@
+#!/usr/bin/env bash
+set -euo pipefail
+
+shellcheck --severity=error merge2out tests/*.sh
+for test in tests/*.sh; do
+  bash "$test"
+done

--- a/tests/merge2out_help.sh
+++ b/tests/merge2out_help.sh
@@ -1,8 +1,11 @@
 #!/usr/bin/env bash
 set -euo pipefail
 
-output=$(./merge2out --help 2>&1 || true)
-if [[ $output != *"build system"* ]]; then
+if ! output=$(./merge2out --help 2>&1); then
+  echo "merge2out --help failed" >&2
+  exit 1
+fi
+if [[ $output != *"build system"* ]] || [[ $output != *"Usage"* ]]; then
   echo "Unexpected output from merge2out --help" >&2
   exit 1
 fi

--- a/tests/merge2out_non_root.sh
+++ b/tests/merge2out_non_root.sh
@@ -1,0 +1,11 @@
+#!/usr/bin/env bash
+set -euo pipefail
+
+if output=$(su nobody -s /bin/bash -c 'GITHUB_ACTIONS=1 ./merge2out' 2>&1); then
+  echo "merge2out should fail when not run as root" >&2
+  exit 1
+fi
+if [[ $output != *"Must be root"* ]]; then
+  echo "Unexpected output: $output" >&2
+  exit 1
+fi


### PR DESCRIPTION
## Summary
- Add `--help` flag to `merge2out` with usage guidance
- Expand test suite and introduce test runner
- Update contributing guide to use `run-tests.sh`

## Testing
- `bash -x ./run-tests.sh`


------
https://chatgpt.com/codex/tasks/task_e_68a243e98378832da69085f0f7688fa6