### PR TITLE
Ensure AbiWord build installs wv library

### DIFF
--- a/woof-code/rootfs-petbuilds/abiword/petbuild
+++ b/woof-code/rootfs-petbuilds/abiword/petbuild
@@ -5,6 +5,9 @@ download() {
 }
 
 build() {
+    if ! pkg-config --exists wv-1.0; then
+        (cd ../wv && ./petbuild)
+    fi
     tar -xzf abiword-3.0.5.tar.gz
     cd abiword-3.0.5
     patch -p1 < ../enchant-2.1.patch

--- a/woof-code/rootfs-petbuilds/wv/petbuild
+++ b/woof-code/rootfs-petbuilds/wv/petbuild
@@ -1,0 +1,16 @@
+#!/bin/sh
+
+# Build the wv library required by AbiWord.
+# Source tarball obtained from Debian's mirrors.
+
+download() {
+    [ -f wv-1.2.9.tar.gz ] || wget -t 3 -T 60 -O wv-1.2.9.tar.gz https://deb.debian.org/debian/pool/main/w/wv/wv_1.2.9.orig.tar.gz
+}
+
+build() {
+    tar -xzf wv-1.2.9.tar.gz
+    cd wv-1.2.9
+    ./configure --prefix=/usr
+    make install
+}
+


### PR DESCRIPTION
## Summary
- add petbuild script to compile the wv library
- make abiword petbuild build wv when missing

## Testing
- `shellcheck woof-code/rootfs-petbuilds/wv/petbuild woof-code/rootfs-petbuilds/abiword/petbuild`

------
https://chatgpt.com/codex/tasks/task_e_68a240584608832da93b6cef986c2a82