### PR TITLE
Install libwv-dev for Ubuntu Jammy workflow

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -38,6 +38,9 @@ on:
       runner:
         type: string
         default: 'ubuntu-24.04'
+      extra-deps:
+        type: string
+        default: ''
 
 jobs:
   build:
@@ -89,7 +92,7 @@ jobs:
     - name: Install dependencies
       run: |
         sudo apt-get update -qq
-        sudo apt-get install -y --no-install-recommends dc debootstrap librsvg2-bin zstd libxml2-utils syslinux-utils xorriso meson ninja-build cmake
+        sudo apt-get install -y --no-install-recommends dc debootstrap librsvg2-bin zstd libxml2-utils syslinux-utils xorriso meson ninja-build cmake ${{ inputs.extra-deps }}
         [ ${{ inputs.compat-distro }} != devuan ] || curl https://git.devuan.org/devuan/debootstrap/raw/branch/master/scripts/ceres | sudo tee /usr/share/debootstrap/scripts/`echo ${{ inputs.compat-distro-version }} | sed s/64$//`
     - name: 0setup
       timeout-minutes: 10

--- a/.github/workflows/ubuntu-jammy64.yml
+++ b/.github/workflows/ubuntu-jammy64.yml
@@ -18,3 +18,4 @@ jobs:
       artifact: ${{ github.workflow }}-${{ github.run_number }}
       retention: 31
       runner: 'ubuntu-22.04'
+      extra-deps: libwv-dev


### PR DESCRIPTION
## Summary
- allow extra dependencies in reusable build workflow
- install libwv-dev for ubuntu-jammy64 builds to satisfy AbiWord linker

## Testing
- `./run-tests.sh`
- `yamllint .github/workflows/build.yml .github/workflows/ubuntu-jammy64.yml` *(fails: line-length and indentation errors)*

------
https://chatgpt.com/codex/tasks/task_e_68a24680da88832d864a0139dd4fa10c