### PR TITLE
Use iproute2 tools in ipinfo script

### DIFF
--- a/woof-code/rootfs-skeleton/usr/sbin/ipinfo
+++ b/woof-code/rootfs-skeleton/usr/sbin/ipinfo
@@ -51,9 +51,9 @@ get_data()
 
 	# tab 1 - interfaces
 	var01=`echo $(gettext 'Hostname:') "$HOSTNAME"`
-	var02="`ifconfig | tr '>' ')' | tr '<' '('`" #130216 mavrothal: < > mess up gtkdialog.
-	# tab 3 - routing
-	var03="`route -n | sed -e 's%Kernel IP routing table%%'`"
+        var02="`ip addr show | tr '>' ')' | tr '<' '('`" #130216 mavrothal: < > mess up gtkdialog.
+        # tab 3 - routing
+        var03="`ip route`"
 	# tab 2
 	var04="DNS:"
 	var05=`cat /etc/resolv.conf`


### PR DESCRIPTION
## Summary
- Replace deprecated `ifconfig` with `ip addr` when gathering interface info
- Switch routing lookup from `route -n` to modern `ip route`
- Drop parsing tailored for legacy command output

## Testing
- `./run-tests.sh`

------
https://chatgpt.com/codex/tasks/task_e_68a24a5bfae0832da7bc3477f1c0f356