### PR TITLE
Replace ifconfig with ip in pdiag

### DIFF
--- a/woof-code/rootfs-packages/pdiag/usr/lib/pdiag/pdiag-network
+++ b/woof-code/rootfs-packages/pdiag/usr/lib/pdiag/pdiag-network
@@ -63,7 +63,7 @@ fi
 grep dhcpcd /var/log/messages > $DIAGSUBDIR/dhcpcd.log
 [ -f /tmp/dhcpcd.log ] && cp -f /tmp/dhcpcd.log $DIAGSUBDIR/dhcpcd_last_viewed.log 2> /dev/null
 iwconfig 2> /dev/null | sed -e 's/\(Encryption key:\).*/\1(removed by pdiag)/' > $DIAGSUBDIR/iwconfig.txt #131211
-ifconfig > $DIAGSUBDIR/ifconfig.txt 2> /dev/null
+ip addr show > $DIAGSUBDIR/ifconfig.txt 2> /dev/null
 cp -f /etc/resolv.conf $DIAGSUBDIR/ 2> /dev/null
 cp -f /etc/resolv.conf.bak $DIAGSUBDIR/ 2> /dev/null
 cp -f /usr/etc/resolvconf.conf.bak $DIAGSUBDIR/ 2> /dev/null

--- a/woof-code/rootfs-packages/pdiag/usr/sbin/pdiag
+++ b/woof-code/rootfs-packages/pdiag/usr/sbin/pdiag
@@ -69,7 +69,7 @@ cp -f /etc/modules.conf $DIAGDIR/ 2> /dev/null
 cat /proc/devices > $DIAGDIR/proc_devices.txt 2> /dev/null
 cp -f /tmp/usb_modeswitch_scsi-info.log $DIAGDIR/ 2> /dev/null
 cp -f /etc/rc.d/rc.local $DIAGDIR/ 2> /dev/null
-ifconfig > $DIAGDIR/ifconfig.txt 2> /dev/null
+ip addr show > $DIAGDIR/ifconfig.txt 2> /dev/null
 cp -f /root/.packages/user-installed-packages $DIAGDIR/ 2> /dev/null
 cp -f /etc/rc.d/pupstate $DIAGDIR/ 2> /dev/null
 cp -f /tmp/xerrs.log $DIAGDIR/ 2> /dev/null


### PR DESCRIPTION
## Summary
- use `ip addr show` instead of deprecated `ifconfig` in pdiag scripts
- maintain existing `ifconfig.txt` log filenames for compatibility
- verified no other tools depend on the old log format

## Testing
- `./run-tests.sh && echo tests-passed`


------
https://chatgpt.com/codex/tasks/task_e_68a24a5405f4832da25d40d9c9bff0c3