### PR TITLE
Replace ifconfig with ip utilities

### DIFF
--- a/woof-code/rootfs-skeleton/usr/bin/xwin
+++ b/woof-code/rootfs-skeleton/usr/bin/xwin
@@ -189,7 +189,7 @@ fi
 # automatic network reconnect. refer /usr/sbin/hostname-set
 if [ -f /tmp/services/network_default_reconnect_required_flag ];then
 	rm -f /tmp/services/network_default_reconnect_required_flag
-	IFCONFIG="`ifconfig | grep '^[pwe]' | grep -v 'wmaster'`" #precaution.
+        IFCONFIG="$(ip -o link show up | awk -F': ' '{print $2}' | grep -E '^[pwe]' | grep -v 'wmaster')" #precaution.
 	[ "$IFCONFIG" = "" ] && network_default_connect #/usr/sbin
 fi
 

--- a/woof-code/rootfs-skeleton/usr/sbin/ifplugstatus
+++ b/woof-code/rootfs-skeleton/usr/sbin/ifplugstatus
@@ -40,9 +40,9 @@ detect_link_beat() {
 		return 11
 	fi
 	#--
-	if [ "$OPT_AUTO" ] ; then
-		busybox ifconfig ${1} up
-	fi
+        if [ "$OPT_AUTO" ] ; then
+                ip link set ${1} up
+        fi
 	#--
 	if [ -e /sys/class/net/${1}/carrier ] ; then
 		read carrier < /sys/class/net/${1}/carrier

--- a/woof-code/rootfs-skeleton/usr/sbin/quicksetup
+++ b/woof-code/rootfs-skeleton/usr/sbin/quicksetup
@@ -278,7 +278,7 @@ if [ "$SET_NETWORK" ];then
  SET_NETWORK=""
  if [ ! -f /var/local/quicksetup-network-check-flag1 ];then
    touch /var/local/quicksetup-network-check-flag2
-    IFCONFIG="`ifconfig | grep '^[pwe]' | grep -v 'wmaster'`" #test network interface up only.
+    IFCONFIG="$(ip -o link show up | awk -F': ' '{print $2}' | grep -E '^[pwe]' | grep -v 'wmaster')" #test network interface up only.
     if [ "$IFCONFIG" ];then
      touch /var/local/quicksetup-network-check-flag1
     fi


### PR DESCRIPTION
## Summary
- use `ip link set` to bring interfaces up in ifplugstatus
- detect network interfaces using `ip -o link show` in quicksetup
- switch xwin's interface detection to `ip -o link show`

## Testing
- `bash woof-code/rootfs-skeleton/usr/sbin/ifplugstatus -a eth0` (warning: operation not permitted, link beat detected)
- `ip -o link show up | awk -F': ' '{print $2}' | grep -E '^[pwe]' | grep -v 'wmaster'`
- `IFCONFIG="$(ip -o link show up | awk -F': ' '{print $2}' | grep -E '^[pwe]' | grep -v 'wmaster')"; [ "$IFCONFIG" = "" ] && echo none || echo $IFCONFIG`
- `./run-tests.sh`

------
https://chatgpt.com/codex/tasks/task_e_68a24a6323ac832d98c5657b38b6db36