### PR TITLE
Run tests in CI with status badge

### DIFF
--- a/.github/workflows/lint-test.yml
+++ b/.github/workflows/lint-test.yml
@@ -1,17 +1,15 @@
-name: lint-and-test
+name: tests
 
 on:
   push:
   pull_request:
 
 jobs:
-  lint-test:
+  tests:
     runs-on: ubuntu-latest
     steps:
     - uses: actions/checkout@v4
     - name: Install dependencies
       run: sudo apt-get update && sudo apt-get install -y shellcheck
-    - name: Run ShellCheck
-      run: shellcheck --severity=error merge2out tests/*.sh
-    - name: Run smoke tests
-      run: bash tests/merge2out_help.sh
+    - name: Run test suite
+      run: ./run-tests.sh

--- a/README.md
+++ b/README.md
@@ -1,5 +1,7 @@
 # woof - the Puppy builder
 
+[![Tests](https://github.com/puppylinux-woof-CE/woof-CE/actions/workflows/lint-test.yml/badge.svg?event=push)](https://github.com/puppylinux-woof-CE/woof-CE/actions/workflows/lint-test.yml)
+
 Currently supported:
 
 | Distro        | Version       | Architecture | Status   |


### PR DESCRIPTION
## Summary
- run full test suite via `run-tests.sh` in GitHub Actions
- add dynamic tests badge to README for automatic status updates

## Testing
- `./run-tests.sh`

------
https://chatgpt.com/codex/tasks/task_e_68a24c3e4058832da2ad593cd9673d55