### PR TITLE
Accelerate downloads using aria2c or curl when available

### DIFF
--- a/CHANGELOG
+++ b/CHANGELOG
@@ -1,6 +1,7 @@
 Woof-CE (woof-Community Edition) is  a fork of Barry Kauler's woof2 fossil
 
 These are some prominent changes that happened since WOOF was forked:
+- download_file.sh now uses aria2c or curl when available for faster, more robust downloads
 - kernel-kit
   * Build a woofce kernel the easy way
   * It will patch the kernel with aufs so you don't have to

--- a/woof-code/support/download_file.sh
+++ b/woof-code/support/download_file.sh
@@ -5,59 +5,71 @@
 # $2: download location
 # $3: copy file to $3
 #
+set -euo pipefail
+IFS=$'\n\t'
 
 CURDIR=${PWD}
 
 URL="$1"
-DOWNLOAD_DIR="$2/"
+DOWNLOAD_DIR="${2%/}/"
 COPYTO="$3"
 
 FILE="${URL##*/}"     # basename
 FILE="${FILE//%2B/+}" # un-escape '+'
 
-#==============================================================
-
-if [ ! -f ${DOWNLOAD_DIR}"${FILE}" ] ; then
-	mkdir -p ${DOWNLOAD_DIR}
-	if [ -f "$URL" ] ; then # full path
-		cp -a "$URL" "${FILE}"
-	else
-		case "$URL" in
-		file://*)
-			FPATH="${URL#file://}"
-			cp -f "${FPATH}" ${DOWNLOAD_DIR}/ || exit 1
-			;;
-
-		*)
-			wget -P ${DOWNLOAD_DIR} --no-check-certificate "${URL}"
-			if [ $? -ne 0 ] ; then
-				rm -fv ${DOWNLOAD_DIR}"${FILE}"
-				exit 1
-			fi
-			;;
-		esac
-	fi
-fi
-
-if [ ! -f ${DOWNLOAD_DIR}"${FILE}" ] ; then
-	exit 1
-fi
-
-if [ ! -f ${DOWNLOAD_DIR}"${FILE}".sha256.txt ] ; then
-	wget -P ${DOWNLOAD_DIR} --no-check-certificate "${URL}".sha256.txt 2>/dev/null
-	[ $? -ne 0 ] && rm -f ${DOWNLOAD_DIR}"${FILE}".sha256.txt
-fi
-
-if [ ! -f ${DOWNLOAD_DIR}"${FILE}".sha256.txt ] ; then
-	if [ ! -f ${DOWNLOAD_DIR}"${FILE}".md5.txt ] ; then
-		wget -P ${DOWNLOAD_DIR} --no-check-certificate "${URL}".md5.txt 2>/dev/null
-		[ $? -ne 0 ] && rm -f ${DOWNLOAD_DIR}"${FILE}".md5.txt
-	fi
-fi
+download() {
+        local url="$1"
+        local outdir="$2"
+        local name="${url##*/}"
+        if command -v aria2c >/dev/null 2>&1 ; then
+                aria2c -x 4 -s 4 -d "$outdir" -o "$name" "$url"
+        elif command -v curl >/dev/null 2>&1 ; then
+                curl -L --fail -o "${outdir}${name}" "$url"
+        else
+                wget -P "$outdir" --no-check-certificate "$url"
+        fi
+}
 
 #==============================================================
 
-if [ ! -f ${DOWNLOAD_DIR}"${FILE}".sha256.txt ] && [ ! -f ${DOWNLOAD_DIR}"${FILE}".md5.txt ] ; then
+if [ ! -f "${DOWNLOAD_DIR}${FILE}" ] ; then
+        mkdir -p "${DOWNLOAD_DIR}"
+        if [ -f "$URL" ] ; then # full path
+                cp -a "$URL" "${DOWNLOAD_DIR}${FILE}"
+        else
+                case "$URL" in
+                file://*)
+                        FPATH="${URL#file://}"
+                        cp -f "$FPATH" "$DOWNLOAD_DIR" || exit 1
+                        ;;
+
+                *)
+                        if ! download "$URL" "$DOWNLOAD_DIR" ; then
+                                rm -fv "${DOWNLOAD_DIR}${FILE}"
+                                exit 1
+                        fi
+                        ;;
+                esac
+        fi
+fi
+
+if [ ! -f "${DOWNLOAD_DIR}${FILE}" ] ; then
+        exit 1
+fi
+
+if [ ! -f "${DOWNLOAD_DIR}${FILE}.sha256.txt" ] ; then
+        download "${URL}.sha256.txt" "$DOWNLOAD_DIR" 2>/dev/null || rm -f "${DOWNLOAD_DIR}${FILE}.sha256.txt"
+fi
+
+if [ ! -f "${DOWNLOAD_DIR}${FILE}.sha256.txt" ] ; then
+        if [ ! -f "${DOWNLOAD_DIR}${FILE}.md5.txt" ] ; then
+                download "${URL}.md5.txt" "$DOWNLOAD_DIR" 2>/dev/null || rm -f "${DOWNLOAD_DIR}${FILE}.md5.txt"
+        fi
+fi
+
+#==============================================================
+
+if [ ! -f "${DOWNLOAD_DIR}${FILE}.sha256.txt" ] && [ ! -f "${DOWNLOAD_DIR}${FILE}.md5.txt" ] ; then
 	echo
 	echo "*** No checksum found for $FILE"
 	echo "*** Download was successful, so creating checksum..."
@@ -67,9 +79,9 @@ if [ ! -f ${DOWNLOAD_DIR}"${FILE}".sha256.txt ] && [ ! -f ${DOWNLOAD_DIR}"${FILE
 	[ "${DOWNLOAD_DIR}" ] && cd "$CURDIR"
 fi
 
-if [ -f ${DOWNLOAD_DIR}"${FILE}".sha256.txt ] ; then
-	[ "${DOWNLOAD_DIR}" ] && cd "${DOWNLOAD_DIR}"
-	if ! sha256sum -c "${FILE}".sha256.txt ; then
+if [ -f "${DOWNLOAD_DIR}${FILE}.sha256.txt" ] ; then
+        [ "${DOWNLOAD_DIR}" ] && cd "${DOWNLOAD_DIR}"
+        if ! sha256sum -c "${FILE}".sha256.txt ; then
 		echo
 		echo "*** ERROR: checksum failed, $FILE"
 		echo "*** located at $PWD"
@@ -80,9 +92,9 @@ if [ -f ${DOWNLOAD_DIR}"${FILE}".sha256.txt ] ; then
 	[ "${DOWNLOAD_DIR}" ] && cd "$CURDIR"
 fi
 
-if [ -f ${DOWNLOAD_DIR}"${FILE}".md5.txt ] ; then
-	[ "${DOWNLOAD_DIR}" ] && cd "${DOWNLOAD_DIR}"
-	if ! md5sum -c "${FILE}".md5.txt ; then
+if [ -f "${DOWNLOAD_DIR}${FILE}.md5.txt" ] ; then
+        [ "${DOWNLOAD_DIR}" ] && cd "${DOWNLOAD_DIR}"
+        if ! md5sum -c "${FILE}".md5.txt ; then
 		echo
 		echo "*** ERROR: checksum failed, $FILE"
 		echo "*** located at $PWD"
@@ -96,7 +108,7 @@ fi
 #==============================================================
 
 if [ "${COPYTO}" ] ; then
-	cp -fv ${DOWNLOAD_DIR}"${FILE}" ${COPYTO}
+        cp -fv "${DOWNLOAD_DIR}${FILE}" "$COPYTO"
 fi
 
 exit 0


### PR DESCRIPTION
## Summary
- enhance `download_file.sh` to leverage `aria2c` or `curl` for faster, more robust downloads while retaining `wget` fallback
- document new download behavior in `CHANGELOG`

## Testing
- `shellcheck woof-code/support/download_file.sh`
- `./run-tests.sh`


------
https://chatgpt.com/codex/tasks/task_e_68a260f7bffc832dba67df5b4bb9f2e6