### PR TITLE
Handle non-root test run via sudo

### DIFF
--- a/tests/merge2out_non_root.sh
+++ b/tests/merge2out_non_root.sh
@@ -1,9 +1,16 @@
 #!/usr/bin/env bash
 set -euo pipefail
 
-if output=$(su nobody -s /bin/bash -c 'GITHUB_ACTIONS=1 ./merge2out' 2>&1); then
-  echo "merge2out should fail when not run as root" >&2
-  exit 1
+if command -v sudo >/dev/null; then
+  if output=$(sudo -n -u nobody env GITHUB_ACTIONS=1 ./merge2out 2>&1); then
+    echo "merge2out should fail when not run as root" >&2
+    exit 1
+  fi
+else
+  if output=$(su nobody -s /bin/bash -c 'GITHUB_ACTIONS=1 ./merge2out' 2>&1); then
+    echo "merge2out should fail when not run as root" >&2
+    exit 1
+  fi
 fi
 if [[ $output != *"Must be root"* ]]; then
   echo "Unexpected output: $output" >&2


### PR DESCRIPTION
## Summary
- ensure merge2out non-root test uses sudo when available to avoid authentication prompts

## Testing
- `./run-tests.sh`


------
https://chatgpt.com/codex/tasks/task_e_68a2627c46cc832d81f8d0a0bb24df57