### PR TITLE
Enable strict mode in build scripts

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -10,6 +10,7 @@ Thank you for your interest in contributing to woof-CE.
 ## Coding guidelines
 - Shell scripts should target POSIX `sh` unless `bash` features are required.
 - Avoid style warnings reported by ShellCheck where practical.
+- Begin each shell script with `set -euo pipefail` after the shebang to enforce strict error handling.
 - Keep scripts small and composable; functions are preferred over large blocks.
 
 ## Reporting issues

--- a/woof-code/0setup
+++ b/woof-code/0setup
@@ -1,4 +1,5 @@
 #!/bin/bash
+set -euo pipefail
 #(c) Copyright 2009 Barry Kauler.
 #120825 debian/ubuntu: merge -updates dbs.
 #121102 file DISTRO_SPECS has new variable DISTRO_DB_SUBNAME. ex: for 14.0-based slacko, DISTRO_DB_SUBNAME=slacko14

--- a/woof-code/1download
+++ b/woof-code/1download
@@ -1,4 +1,5 @@
 #!/bin/bash
+set -euo pipefail
 #(c) Copyright 2009 Barry Kauler.
 #110819 support/findpkgs is new script to find all pkgs to be used in Puppy build.
 

--- a/woof-code/2createpackages
+++ b/woof-code/2createpackages
@@ -1,4 +1,5 @@
 #!/bin/bash
+set -euo pipefail
 #(c) Copyright Barry Kauler 2009.
 # grab binary ubuntu/debian/slackware packages and build puppy packages.
 # to packages-$DISTRO_FILE_PREFIX/, into the "generic name". Note that one generic

--- a/woof-code/3builddistro
+++ b/woof-code/3builddistro
@@ -1,4 +1,5 @@
 #!/bin/bash
+set -euo pipefail
 # new for fatdog style kernel
 
 export LANG=C #faster.


### PR DESCRIPTION
## Summary
- enforce `set -euo pipefail` in 0setup, 1download, 2createpackages, and 3builddistro
- document strict mode requirement in CONTRIBUTING

## Testing
- `bash -n woof-code/0setup woof-code/1download woof-code/2createpackages woof-code/3builddistro`
- `./run-tests.sh`

------
https://chatgpt.com/codex/tasks/task_e_68a288a261dc832d81a48f36b583e0d2