### PR TITLE
Add manifest parser with YAML schema and examples

### DIFF
--- a/build-manifest/examples/kernel.yaml
+++ b/build-manifest/examples/kernel.yaml
@@ -1,0 +1,19 @@
+stages:
+  - name: fetch-kernel
+    run: ./fetch-kernel.sh
+    deps: []
+    artifacts:
+      - path: kernel-source.tar.gz
+        description: Downloaded kernel sources
+  - name: compile-kernel
+    run: ./compile-kernel.sh
+    deps: [fetch-kernel]
+    artifacts:
+      - path: bzImage
+        description: Compiled kernel image
+  - name: package-kernel
+    run: ./package-kernel.sh
+    deps: [compile-kernel]
+    artifacts:
+      - path: kernel.txz
+        description: Compressed kernel package

--- a/build-manifest/examples/package.yaml
+++ b/build-manifest/examples/package.yaml
@@ -1,0 +1,19 @@
+stages:
+  - name: fetch-src
+    run: ./fetch-source.sh
+    deps: []
+    artifacts:
+      - path: src.tar.gz
+        description: Source code archive
+  - name: build
+    run: ./build.sh
+    deps: [fetch-src]
+    artifacts:
+      - path: pkg.txz
+        description: Compiled package
+  - name: install
+    run: ./install.sh
+    deps: [build]
+    artifacts:
+      - path: /tmp/pkg-installed
+        description: Installation directory

--- a/build-manifest/parser.py
+++ b/build-manifest/parser.py
@@ -1,0 +1,87 @@
+#!/usr/bin/env python3
+"""Parse build manifest YAML into a DAG of callable build stages."""
+from __future__ import annotations
+
+import sys
+from collections import defaultdict, deque
+from dataclasses import dataclass, field
+from typing import Callable, Dict, List
+
+import yaml
+
+
+@dataclass
+class Stage:
+    name: str
+    run: str
+    deps: List[str] = field(default_factory=list)
+    artifacts: List[Dict[str, str]] = field(default_factory=list)
+
+
+def load_manifest(path: str) -> Dict[str, Stage]:
+    with open(path, "r", encoding="utf-8") as handle:
+        data = yaml.safe_load(handle)
+    stages: Dict[str, Stage] = {}
+    for entry in data.get("stages", []):
+        stage = Stage(
+            name=entry["name"],
+            run=entry["run"],
+            deps=entry.get("deps", []),
+            artifacts=entry.get("artifacts", []),
+        )
+        stages[stage.name] = stage
+    return stages
+
+
+def topological_order(stages: Dict[str, Stage]) -> List[str]:
+    indegree = {name: 0 for name in stages}
+    for stage in stages.values():
+        for dep in stage.deps:
+            indegree[stage.name] += 1
+    queue: deque[str] = deque(name for name, deg in indegree.items() if deg == 0)
+    order: List[str] = []
+    graph: Dict[str, List[str]] = defaultdict(list)
+    for stage in stages.values():
+        for dep in stage.deps:
+            graph[dep].append(stage.name)
+    while queue:
+        node = queue.popleft()
+        order.append(node)
+        for nbr in graph[node]:
+            indegree[nbr] -= 1
+            if indegree[nbr] == 0:
+                queue.append(nbr)
+    if len(order) != len(stages):
+        raise ValueError("Cycle detected in manifest")
+    return order
+
+
+def build_functions(stages: Dict[str, Stage]) -> Dict[str, Callable[[], None]]:
+    order = topological_order(stages)
+    funcs: Dict[str, Callable[[], None]] = {}
+    for name in order:
+        stage = stages[name]
+
+        def _make(stage: Stage = stage) -> Callable[[], None]:
+            def run() -> None:
+                print(f"Running {stage.name}: {stage.run}")
+            return run
+
+        funcs[name] = _make()
+    return funcs
+
+
+def main() -> None:
+    if len(sys.argv) != 2:
+        print(f"Usage: {sys.argv[0]} MANIFEST", file=sys.stderr)
+        sys.exit(1)
+    stages = load_manifest(sys.argv[1])
+    order = topological_order(stages)
+    funcs = build_functions(stages)
+    print(f"Build order: {order}")
+    for name in order:
+        funcs[name]()
+
+
+if __name__ == "__main__":
+    main()

--- a/build-manifest/schema.yaml
+++ b/build-manifest/schema.yaml
@@ -1,0 +1,35 @@
+type: object
+required:
+  - stages
+properties:
+  stages:
+    type: array
+    description: Ordered collection of build stages
+    items:
+      type: object
+      required: [name, run]
+      properties:
+        name:
+          type: string
+          description: Unique stage identifier
+        run:
+          type: string
+          description: Command executed for this stage
+        deps:
+          type: array
+          description: Names of prerequisite stages
+          items:
+            type: string
+        artifacts:
+          type: array
+          description: Outputs produced by this stage
+          items:
+            type: object
+            required: [path]
+            properties:
+              path:
+                type: string
+                description: Relative file path of the artifact
+              description:
+                type: string
+                description: Human readable description of the artifact

--- a/tests/manifest_parser.sh
+++ b/tests/manifest_parser.sh
@@ -1,0 +1,8 @@
+#!/usr/bin/env bash
+set -euo pipefail
+
+output=$(python3 build-manifest/parser.py build-manifest/examples/kernel.yaml)
+echo "$output" | head -n 1 | grep -Fq "Build order: ['fetch-kernel', 'compile-kernel', 'package-kernel']"
+
+output=$(python3 build-manifest/parser.py build-manifest/examples/package.yaml)
+echo "$output" | head -n 1 | grep -Fq "Build order: ['fetch-src', 'build', 'install']"


### PR DESCRIPTION
## Summary
- define YAML schema for build stages, dependencies, and artifacts
- implement Python parser that turns manifests into DAG of executable stages
- add kernel and package build manifest examples with tests

## Testing
- `bash -x ./run-tests.sh`

------
https://chatgpt.com/codex/tasks/task_e_68a29d198450832dbc52cb2177a4e906