### PR TITLE
Introduce plugin-based build stages

### DIFF
--- a/woof-code/build.sh
+++ b/woof-code/build.sh
@@ -1,48 +1,9 @@
 #!/bin/sh
-#
-# build from start to finish
-# 
-# this will consume lots of bandwidth and resources
-#
-# think about who pays the server bills before running this
-#
-# build.sh [n]
-#   n=0: start from 0setup
-#   n=1: start from 1download
-#   n=2: start from 2createpackages
-#   n=3: start from 3buildistro
-#
+# Wrapper to run build stages via plugins.
 
 if [ ! -f ./WOOFMERGEVARS ] ; then
-	echo "run merge2out"
-	exit 1
+        echo "run merge2out"
+        exit 1
 fi
 
-for i in $@ ; do
-	case $i in
-		-release|release) RELEASE=release ; shift ;;
-	esac
-done
-
-# run helper scripts and log the output (script.log)
-
-case $1 in
-0|"")
-	./xlog 0setup a             #requires a param or ENTER the 2nd time you run it
-	./xlog 1download            #[pkg]
-	./xlog 2createpackages -all #or pkg
-	./xlog 3builddistro ${RELEASE}
-	;;
-1)
-	./xlog 1download            #[pkg]
-	./xlog 2createpackages -all #or pkg
-	./xlog 3builddistro ${RELEASE}
-	;;
-2)
-	./xlog 2createpackages -all #or pkg
-	./xlog 3builddistro ${RELEASE}
-	;;
-3)
-	./xlog 3builddistro ${RELEASE}
-	;;
-esac
+python3 plugin_runner.py "$@"

--- a/woof-code/plugin_manifest.json
+++ b/woof-code/plugin_manifest.json
@@ -1,0 +1,8 @@
+{
+  "plugins": [
+    "plugins.setup.SetupPlugin",
+    "plugins.download.DownloadPlugin",
+    "plugins.createpackages.CreatePackagesPlugin",
+    "plugins.builddistro.BuildDistroPlugin"
+  ]
+}

--- a/woof-code/plugin_runner.py
+++ b/woof-code/plugin_runner.py
@@ -1,0 +1,49 @@
+"""Dynamic loader for build plugins."""
+from __future__ import annotations
+
+import importlib
+import json
+import os
+import sys
+from typing import Any, Dict, List
+
+BASE_DIR = os.path.dirname(os.path.abspath(__file__))
+sys.path.insert(0, BASE_DIR)
+
+
+def load_manifest(path: str) -> List[str]:
+    with open(path, "r", encoding="utf-8") as fh:
+        data = json.load(fh)
+    return data.get("plugins", [])
+
+
+def load_plugin(path: str):
+    module_name, class_name = path.rsplit(".", 1)
+    module = importlib.import_module(module_name)
+    return getattr(module, class_name)
+
+
+def main(argv: List[str]) -> None:
+    start = 0
+    release = False
+    for arg in list(argv):
+        if arg.isdigit():
+            start = int(arg)
+            argv.remove(arg)
+    if any(a in ("-release", "release") for a in argv):
+        release = True
+    manifest_path = os.path.join(BASE_DIR, "plugin_manifest.json")
+    plugin_paths = load_manifest(manifest_path)[start:]
+    context: Dict[str, Any] = {"cwd": BASE_DIR, "release": release}
+    for plugin_path in plugin_paths:
+        plugin_cls = load_plugin(plugin_path)
+        plugin = plugin_cls()
+        meta = plugin.metadata
+        print(f"=== Running {meta.name} ({meta.description}) ===")
+        plugin.init(context)
+        plugin.run(context)
+        plugin.teardown(context)
+
+
+if __name__ == "__main__":
+    main(sys.argv[1:])

--- a/woof-code/plugins/__init__.py
+++ b/woof-code/plugins/__init__.py
@@ -1,0 +1,2 @@
+"""Plugin package for build stages."""
+

--- a/woof-code/plugins/builddistro.py
+++ b/woof-code/plugins/builddistro.py
@@ -1,0 +1,18 @@
+"""3builddistro stage plugin."""
+from __future__ import annotations
+
+import subprocess
+from typing import Any, Dict
+
+from .interface import Plugin, PluginMetadata
+
+
+class BuildDistroPlugin(Plugin):
+    metadata = PluginMetadata(name="3builddistro", description="Assemble final distribution")
+
+    def run(self, context: Dict[str, Any]) -> None:
+        cwd = context["cwd"]
+        cmd = ["./xlog", "3builddistro"]
+        if context.get("release"):
+            cmd.append("-release")
+        subprocess.check_call(cmd, cwd=cwd)

--- a/woof-code/plugins/createpackages.py
+++ b/woof-code/plugins/createpackages.py
@@ -1,0 +1,15 @@
+"""2createpackages stage plugin."""
+from __future__ import annotations
+
+import subprocess
+from typing import Any, Dict
+
+from .interface import Plugin, PluginMetadata
+
+
+class CreatePackagesPlugin(Plugin):
+    metadata = PluginMetadata(name="2createpackages", description="Create package layer")
+
+    def run(self, context: Dict[str, Any]) -> None:
+        cwd = context["cwd"]
+        subprocess.check_call(["./xlog", "2createpackages", "-all"], cwd=cwd)

--- a/woof-code/plugins/download.py
+++ b/woof-code/plugins/download.py
@@ -1,0 +1,15 @@
+"""1download stage plugin."""
+from __future__ import annotations
+
+import subprocess
+from typing import Any, Dict
+
+from .interface import Plugin, PluginMetadata
+
+
+class DownloadPlugin(Plugin):
+    metadata = PluginMetadata(name="1download", description="Download required packages")
+
+    def run(self, context: Dict[str, Any]) -> None:
+        cwd = context["cwd"]
+        subprocess.check_call(["./xlog", "1download"], cwd=cwd)

--- a/woof-code/plugins/interface.py
+++ b/woof-code/plugins/interface.py
@@ -1,0 +1,33 @@
+"""Plugin interface for woof build stages."""
+from __future__ import annotations
+
+from dataclasses import dataclass
+from typing import Any, Dict
+
+
+@dataclass
+class PluginMetadata:
+    """Descriptive information about a plugin."""
+
+    name: str
+    description: str = ""
+    version: str = "1.0"
+
+
+class Plugin:
+    """Base class for build plugins."""
+
+    metadata: PluginMetadata
+
+    def __init__(self) -> None:
+        if not hasattr(self, "metadata"):
+            raise ValueError("Plugin subclass must define metadata")
+
+    def init(self, context: Dict[str, Any]) -> None:  # noqa: D401
+        """Prepare plugin state."""
+
+    def run(self, context: Dict[str, Any]) -> None:  # noqa: D401
+        """Execute plugin action."""
+
+    def teardown(self, context: Dict[str, Any]) -> None:  # noqa: D401
+        """Clean up plugin state."""

--- a/woof-code/plugins/setup.py
+++ b/woof-code/plugins/setup.py
@@ -1,0 +1,15 @@
+"""0setup stage plugin."""
+from __future__ import annotations
+
+import subprocess
+from typing import Any, Dict
+
+from .interface import Plugin, PluginMetadata
+
+
+class SetupPlugin(Plugin):
+    metadata = PluginMetadata(name="0setup", description="Initial setup stage")
+
+    def run(self, context: Dict[str, Any]) -> None:
+        cwd = context["cwd"]
+        subprocess.check_call(["./xlog", "0setup", "a"], cwd=cwd)


### PR DESCRIPTION
## Summary
- add a plugin interface with init/run/teardown metadata
- refactor build stages into plugins loaded from a manifest
- update build script to execute stages through the plugin loader

## Testing
- `python3 woof-code/plugin_runner.py 4`
- `./run-tests.sh`


------
https://chatgpt.com/codex/tasks/task_e_68a29d1d4dc0832db9baed41466cc8e6