### PR TITLE
Add SAT-based package solver with diagnostics

### DIFF
--- a/pkg_solver.py
+++ b/pkg_solver.py
@@ -1,0 +1,66 @@
+"""Package dependency solver using a SAT solver.
+
+Encodes package requirements and conflicts as boolean formulas and
+uses MiniSat to compute valid configurations. When the set of
+requested packages has no satisfying assignment, a diagnostic
+exception with an unsatisfiable core is raised.
+"""
+from dataclasses import dataclass, field
+from typing import Dict, Iterable, List, Sequence
+
+from pysat.formula import CNF
+from pysat.solvers import Minisat22
+
+
+class UnsatisfiableError(Exception):
+    """Raised when the package constraints cannot be satisfied."""
+
+    def __init__(self, core: Sequence[str]):
+        self.core = list(core)
+        msg = "No satisfying assignment; conflicting packages: " + ", ".join(self.core)
+        super().__init__(msg)
+
+
+@dataclass
+class PackageProblem:
+    """Represents a package constraint problem."""
+
+    packages: Iterable[str]
+    requires: Dict[str, Iterable[str]] = field(default_factory=dict)
+    conflicts: Dict[str, Iterable[str]] = field(default_factory=dict)
+
+    def __post_init__(self) -> None:
+        self.packages = list(self.packages)
+        self.var_map = {pkg: i + 1 for i, pkg in enumerate(self.packages)}
+        self.cnf = CNF()
+        self._encode_constraints()
+
+    def _encode_constraints(self) -> None:
+        """Encode requirements and conflicts into CNF."""
+        for pkg, deps in self.requires.items():
+            for dep in deps:
+                self.cnf.append([-self.var_map[pkg], self.var_map[dep]])
+        for pkg, confs in self.conflicts.items():
+            for conf in confs:
+                self.cnf.append([-self.var_map[pkg], -self.var_map[conf]])
+
+    def solve(self, requested: Sequence[str]) -> Dict[str, bool]:
+        """Solve for a valid package configuration.
+
+        Args:
+            requested: Packages that must be installed.
+
+        Returns:
+            A mapping of package name to boolean indicating installation.
+
+        Raises:
+            UnsatisfiableError: if the requested packages cannot be satisfied.
+        """
+        solver = Minisat22(bootstrap_with=self.cnf.clauses)
+        assumptions = [self.var_map[pkg] for pkg in requested]
+        if solver.solve(assumptions=assumptions):
+            model = set(solver.get_model())
+            return {pkg: (var in model) for pkg, var in self.var_map.items()}
+        core_vars = solver.get_core()
+        core_pkgs = [pkg for pkg, var in self.var_map.items() if var in core_vars]
+        raise UnsatisfiableError(core_pkgs)

--- a/tests/pkg_solver.sh
+++ b/tests/pkg_solver.sh
@@ -1,0 +1,24 @@
+#!/usr/bin/env bash
+set -euo pipefail
+
+python -m pip install --quiet python-sat
+
+python - <<'PY'
+from pkg_solver import PackageProblem, UnsatisfiableError
+
+packages = ['A', 'B', 'C']
+requires = {'A': ['B']}
+conflicts = {'B': ['C']}
+problem = PackageProblem(packages, requires, conflicts)
+
+# Satisfiable request
+solution = problem.solve(['A'])
+assert solution['A'] and solution['B'] and not solution['C']
+
+# Unsatisfiable request exposes diagnostic
+try:
+    problem.solve(['A', 'C'])
+    raise SystemExit('unexpected satisfiable result')
+except UnsatisfiableError as exc:
+    print(exc)
+PY


### PR DESCRIPTION
## Summary
- Add `pkg_solver.py` to encode package requirements/conflicts into CNF and use MiniSat to resolve valid configurations.
- Provide detailed diagnostics via `UnsatisfiableError` when requested packages cannot be satisfied.
- Introduce shell-based test to validate both satisfiable and unsatisfiable scenarios.

## Testing
- `./run-tests.sh`

------
https://chatgpt.com/codex/tasks/task_e_68a29d20a1dc832d8056ad0bbd299150