### PR TITLE
feat: add containerized build tooling

### DIFF
--- a/README.md
+++ b/README.md
@@ -66,6 +66,29 @@ Woof-CE has five directories:
   - `build.sh`           : builds the kernel based on the configuration defined in build.conf.
 - initrd-progs: scripts and files to generate the initial ramdisk
 
+# Containerized builds
+
+woof-CE ships scripts and container definitions that provide a pinned
+toolchain for reproducible builds without having to prepare a host
+environment.
+
+Build the image:
+
+```
+./containers/build.sh
+```
+
+Run any pipeline command inside the container:
+
+```
+./run-in-container.sh ./merge2out
+```
+
+The helper scripts default to Podman when available and fall back to
+Docker.  A different container image can be used by exporting the
+`WOOF_CONTAINER_IMAGE` variable, and the runtime may be overridden via
+`CONTAINER_RUNTIME`.
+
 # Preparation
 
 1. Suitable build environment

--- a/containers/Dockerfile
+++ b/containers/Dockerfile
@@ -1,0 +1,15 @@
+FROM debian@sha256:40d2cfd4c196e9290a26ec34beadd0f24e54284b1cef99abac608460a8e7247c
+
+# Use a Debian snapshot to pin package versions for reproducible builds
+ARG DEBIAN_SNAPSHOT=20240311T000000Z
+RUN echo "deb [check-valid-until=no] http://snapshot.debian.org/archive/debian/${DEBIAN_SNAPSHOT}/ bookworm main" > /etc/apt/sources.list \
+    && apt-get -o Acquire::Check-Valid-Until=false update \
+    && apt-get install -y --no-install-recommends \
+       bc \
+       build-essential \
+       ca-certificates \
+       git \
+       wget \
+    && rm -rf /var/lib/apt/lists/*
+
+WORKDIR /workspace

--- a/containers/build.sh
+++ b/containers/build.sh
@@ -1,0 +1,15 @@
+#!/usr/bin/env bash
+set -euo pipefail
+
+IMAGE="${WOOF_CONTAINER_IMAGE:-woof-ce:local}"
+
+if command -v podman >/dev/null 2>&1; then
+  RUNTIME="${CONTAINER_RUNTIME:-podman}"
+elif command -v docker >/dev/null 2>&1; then
+  RUNTIME="${CONTAINER_RUNTIME:-docker}"
+else
+  echo "No container runtime found" >&2
+  exit 1
+fi
+
+exec "$RUNTIME" build -t "$IMAGE" -f "$(dirname "$0")/Dockerfile" "$(dirname "$0")"

--- a/run-in-container.sh
+++ b/run-in-container.sh
@@ -1,0 +1,19 @@
+#!/usr/bin/env bash
+set -euo pipefail
+
+IMAGE="${WOOF_CONTAINER_IMAGE:-woof-ce:local}"
+
+if command -v podman >/dev/null 2>&1; then
+  RUNTIME="${CONTAINER_RUNTIME:-podman}"
+elif command -v docker >/dev/null 2>&1; then
+  RUNTIME="${CONTAINER_RUNTIME:-docker}"
+else
+  echo "Neither podman nor docker is available" >&2
+  exit 1
+fi
+
+exec "$RUNTIME" run --rm -it \
+  -v "$PWD":/workspace \
+  -w /workspace \
+  "$IMAGE" \
+  "$@"


### PR DESCRIPTION
## Summary
- provide Debian-based container definition pinned to a snapshot
- add scripts to build and run the pipeline with Docker/Podman
- document how to override the container image for custom builds

## Testing
- `shellcheck containers/build.sh run-in-container.sh`
- `./run-tests.sh`


------
https://chatgpt.com/codex/tasks/task_e_68a29d2352d0832d8d1b29da35c1d7d4